### PR TITLE
Update development.yaml

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -9,6 +9,9 @@ jobs:
       matrix:
         include:
           - distro: alpine
+            py_ver: '3.12'
+            platform: linux/amd64
+          - distro: alpine
             py_ver: '3.11'
             platform: linux/amd64
           - distro: alpine
@@ -20,8 +23,8 @@ jobs:
           - distro: alpine
             py_ver: '3.8'
             platform: linux/amd64
-          - distro: alpine
-            py_ver: '3.7'
+          - distro: debian
+            py_ver: '3.12'
             platform: linux/amd64
           - distro: debian
             py_ver: '3.11'
@@ -35,18 +38,6 @@ jobs:
           - distro: debian
             py_ver: '3.8'
             platform: linux/amd64
-          - distro: debian
-            py_ver: '3.7'
-            platform: linux/amd64
-          # - distro: debian
-          #   py_ver: 3.9
-          #   platform: linux/arm64
-          # - distro: debian
-          #   py_ver: 3.8
-          #   platform: linux/arm64
-          # - distro: debian
-          #   py_ver: 3.7
-          #   platform: linux/arm64
     env:
       DISTRO: ${{matrix.distro}}
       PY_VER: ${{matrix.py_ver}}
@@ -85,6 +76,9 @@ jobs:
       matrix:
         include:
           - distro: alpine
+            py_ver: '3.12'
+            platform: linux/amd64
+          - distro: alpine
             py_ver: '3.11'
             platform: linux/amd64
           - distro: alpine
@@ -96,8 +90,8 @@ jobs:
           - distro: alpine
             py_ver: '3.8'
             platform: linux/amd64
-          - distro: alpine
-            py_ver: '3.7'
+          - distro: debian
+            py_ver: '3.12'
             platform: linux/amd64
           - distro: debian
             py_ver: '3.11'
@@ -111,18 +105,6 @@ jobs:
           - distro: debian
             py_ver: '3.8'
             platform: linux/amd64
-          - distro: debian
-            py_ver: '3.7'
-            platform: linux/amd64
-          # - distro: debian
-          #   py_ver: 3.9
-          #   platform: linux/arm64
-          # - distro: debian
-          #   py_ver: 3.8
-          #   platform: linux/arm64
-          # - distro: debian
-          #   py_ver: 3.7
-          #   platform: linux/arm64
     env:
       DISTRO: ${{matrix.distro}}
       PY_VER: ${{matrix.py_ver}}
@@ -158,6 +140,9 @@ jobs:
       matrix:
         include:
           - distro: alpine
+            py_ver: '3.12'
+            platform: linux/amd64
+          - distro: alpine
             py_ver: '3.11'
             platform: linux/amd64
           - distro: alpine
@@ -169,8 +154,8 @@ jobs:
           - distro: alpine
             py_ver: '3.8'
             platform: linux/amd64
-          - distro: alpine
-            py_ver: '3.7'
+          - distro: debian
+            py_ver: '3.12'
             platform: linux/amd64
           - distro: debian
             py_ver: '3.11'
@@ -184,18 +169,6 @@ jobs:
           - distro: debian
             py_ver: '3.8'
             platform: linux/amd64
-          - distro: debian
-            py_ver: '3.7'
-            platform: linux/amd64
-          # - distro: debian
-          #   py_ver: 3.9
-          #   platform: linux/arm64
-          # - distro: debian
-          #   py_ver: 3.8
-          #   platform: linux/arm64
-          # - distro: debian
-          #   py_ver: 3.7
-          #   platform: linux/arm64
     env:
       DISTRO: ${{matrix.distro}}
       PY_VER: ${{matrix.py_ver}}


### PR DESCRIPTION
Removed Python 3.7 support and added 3.12 support for docker tests.

This is to address failing tests on https://github.com/datajoint/datajoint-python/pull/1163

@ethho  @dimitri-yatsenko @guzman-raphael 